### PR TITLE
Fix: Search now properly respects databaseName parameter

### DIFF
--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -256,6 +256,9 @@ const search = async (input: SearchInput): Promise<SearchResult> => {
           } catch (e) {
             return JSON.stringify({ success: false, error: "Error checking if record is a group: " + e.toString() });
           }
+        } else if (targetDatabase) {
+          // If a specific database was provided, use its root group to scope the search
+          searchScope = targetDatabase.root();
         } else {
           searchScope = null; // Search all databases
         }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -256,7 +256,7 @@ const search = async (input: SearchInput): Promise<SearchResult> => {
           } catch (e) {
             return JSON.stringify({ success: false, error: "Error checking if record is a group: " + e.toString() });
           }
-        } else if (targetDatabase) {
+        } else if (pDatabaseName) {
           // If a specific database was provided, use its root group to scope the search
           searchScope = targetDatabase.root();
         } else {


### PR DESCRIPTION
## Summary
- Fixed bug where the `search` function ignored the `databaseName` parameter  
- Search results now properly scoped to the specified database when provided

## Problem
When the `databaseName` parameter was provided to the search function without any group parameters, the search would return results from all open databases instead of limiting results to the specified database.

## Solution
When `databaseName` is provided without group parameters, the search is now scoped to that database's root group using `targetDatabase.root()`. This ensures that searches are properly limited to the specified database.

## Testing
- Built successfully with `npm run build`
- Type checking passes with `npm run type-check`
- The fix is a minimal, surgical change that only affects the specific case where a database is specified without group parameters

Fixes the issue described in `devonthink-search-bug-report.md`